### PR TITLE
Small bugfixes

### DIFF
--- a/Sources/SwiftVideo/composer.swift
+++ b/Sources/SwiftVideo/composer.swift
@@ -180,7 +180,7 @@ public class Composer {
                          _ duration: TimePoint = TimePoint(0, 1000)) -> Future<[Bool], Never>? {
         if let element = elements[elementId],
            let state = element.states[stateId] {
-            elements[elementId]?.currentState = stateId
+            element.currentState = stateId
             let futs = [element.picAnimator.setState(state, duration), element.sounAnimator.setState(state, duration)]
             return futs.sequence()
         }
@@ -239,7 +239,7 @@ public class Composer {
     private var scenes: [String: Scene]
     private var elements: [String: ElementAnimator]
 
-    private struct ElementAnimator {
+    private class ElementAnimator {
         init(_ picAnimator: PictureAnimator,
              _ sounAnimator: SoundAnimator,
              _ states: [String: ElementState],

--- a/Sources/SwiftVideo/composer.swift
+++ b/Sources/SwiftVideo/composer.swift
@@ -144,8 +144,10 @@ public class Composer {
           case .elementState(let state):
               return setState(state.elementID, state.stateID, state.duration)
           case .bind(let req):
+              let assetId = req.assetID
+              let elementId = req.elementID
               return action(oneof)?.andThen { [weak self] _ in
-                self?.bind(req.assetID, elementId: req.elementID)
+                self?.bind(assetId, elementId: elementId)
               }
           case .loadFile, .playFile, .stopFile:
               return action(oneof)

--- a/Sources/SwiftVideo/composer.swift
+++ b/Sources/SwiftVideo/composer.swift
@@ -144,8 +144,9 @@ public class Composer {
           case .elementState(let state):
               return setState(state.elementID, state.stateID, state.duration)
           case .bind(let req):
-              bind(req.assetID, elementId: req.elementID)
-              return action(oneof)
+              return action(oneof)?.andThen { [weak self] _ in
+                self?.bind(req.assetID, elementId: req.elementID)
+              }
           case .loadFile, .playFile, .stopFile:
               return action(oneof)
           case .setText:

--- a/Sources/SwiftVideo/dec.video.ffmpeg.swift
+++ b/Sources/SwiftVideo/dec.video.ffmpeg.swift
@@ -30,6 +30,7 @@ public class FFmpegVideoDecoder: Tx<CodedMediaSample, PictureSample> {
             guard let strongSelf = self else {
                 return .gone
             }
+            print("new sample \($0.assetId())")
             return strongSelf.handle($0)
         }
     }

--- a/Sources/SwiftVideo/dec.video.ffmpeg.swift
+++ b/Sources/SwiftVideo/dec.video.ffmpeg.swift
@@ -30,7 +30,6 @@ public class FFmpegVideoDecoder: Tx<CodedMediaSample, PictureSample> {
             guard let strongSelf = self else {
                 return .gone
             }
-            print("new sample \($0.assetId())")
             return strongSelf.handle($0)
         }
     }

--- a/Sources/SwiftVideo/net.flavor.swift
+++ b/Sources/SwiftVideo/net.flavor.swift
@@ -22,12 +22,10 @@ import BrightFutures
 
 public class Flavor {
     public init(_ clock: Clock, onEnded: @escaping LiveOnEnded,
-                onConnection: @escaping (String) -> Void,
                 formatQuery: @escaping (String, String?) -> [MediaFormat]?,
                 onStreamEstablished: @escaping LiveOnConnection) {
         self.clock = clock
         self.sessions = [String: FlavorSession]()
-        self.fnConnection = onConnection
         self.fnStreamEstablished = onStreamEstablished
         self.fnEnded = onEnded
         self.fnFormatQuery = formatQuery
@@ -46,12 +44,7 @@ public class Flavor {
                 dialedOut: false,
                 formatQuery: strongSelf.fnFormatQuery,
                 onEnded: strongSelf.fnEnded,
-                onStreamEstablished: strongSelf.fnStreamEstablished) { [weak self] in
-                    if $0 {
-                        self?.fnConnection(conn.ident)
-                    }
-            }
-
+                onStreamEstablished: strongSelf.fnStreamEstablished) { _ in }
         }
 
         let fnEnded = { [weak self] (conn: Connection) -> Void in
@@ -72,97 +65,110 @@ public class Flavor {
     }
     public func connect(url: URL,
                         group: EventLoopGroup,
-                        workspaceId: String) -> String {
-        guard let host = url.host else {
-            return ""
-        }
-        let port = url.port ?? 3751
-        let sessionId = UUID().uuidString
-
-        let fnConnected = { [weak self] (conn: Connection) -> Void in
-            guard let strongSelf = self else {
+                        forceNew: Bool = false) -> Future<String, RpcError> {
+        Future { [weak self] complete in
+            guard let strongSelf = self, let host = url.host else {
+                complete(.failure(.gone))
                 return
             }
+            let port = url.port ?? 3751
+            let sessionId = UUID().uuidString
 
-            strongSelf.sessions[sessionId] = FlavorSession(strongSelf.clock,
-                conn: conn,
-                dialedOut: true,
-                sessionId: sessionId,
-                formatQuery: strongSelf.fnFormatQuery,
-                onEnded: strongSelf.fnEnded,
-                onStreamEstablished: strongSelf.fnStreamEstablished) { [weak self] in
-                    if $0 {
-                        self?.fnConnection(sessionId)
+            let fnConnected = { [weak self] (conn: Connection) -> Void in
+                guard let strongSelf = self else {
+                    return
+                }
+
+                strongSelf.sessions[sessionId] = FlavorSession(strongSelf.clock,
+                    conn: conn,
+                    dialedOut: true,
+                    url: url.absoluteString,
+                    sessionId: sessionId,
+                    formatQuery: strongSelf.fnFormatQuery,
+                    onEnded: strongSelf.fnEnded,
+                    onStreamEstablished: strongSelf.fnStreamEstablished) {
+                        if $0 {
+                            complete(.success(sessionId))
+                        } else {
+                            complete(.failure(.remote("Did not establish session")))
+                        }
+                }
+            }
+            let fnEnded = { [weak self] (conn: Connection) -> Void in
+                guard let strongSelf = self else {
+                    return
+                }
+                strongSelf.sessions.removeValue(forKey: sessionId)
+            }
+            let urlString = url.absoluteString
+            let existing = strongSelf.sessions.filter { $0.1.url.map { $0 == urlString } ?? false }
+            if let candidate = existing.randomElement(),
+                !forceNew {
+                complete(.success(candidate.1.sessionId))
+            }
+            do {
+                _ = try tcpClient(group: group,
+                          host: host,
+                          port: port,
+                          clock: clock,
+                          connected: fnConnected,
+                          ended: fnEnded).wait()
+            } catch {
+                complete(.failure(.caught(error)))
+            }
+        }
+    }
+
+    public func makePush(_ sessionId: String, token: String) -> Future<Bool, RpcError> {
+        Future { complete in
+            guard let session = sessions[sessionId] else {
+                complete(.failure(.invalidConfiguration))
+                return
+            }
+            do {
+                try session.sendPush(token) { [weak self] _, response, reason, _ in
+                    if response == 0 {
+                        // make a publisher
+                        if let session = self?.sessions[sessionId] {
+                            // We know this has 2 parts because it will have been verified by sendPush
+                            let parts = token.split(separator: "/")
+                            session.makePublisher(UUID().uuidString, String(parts[0]), workspaceToken: String(parts[1]))
+                        }
+                        complete(.success(true))
                     } else {
-
+                        complete(.failure(reason.map { .remote($0) } ?? .unknown))
                     }
+                }
+            } catch {
+                complete(.failure(.caught(error)))
             }
-
         }
-        let fnEnded = { [weak self] (conn: Connection) -> Void in
-            guard let strongSelf = self else {
+    }
+
+    public func makePull(_ sessionId: String, token: String) -> Future<Bool, RpcError> {
+        Future { complete in
+            guard let session = sessions[sessionId] else {
+                complete(.failure(.invalidConfiguration))
                 return
             }
-            strongSelf.sessions.removeValue(forKey: sessionId)
-        }
-        do {
-            _ = try tcpClient(group: group,
-                      host: host,
-                      port: port,
-                      clock: clock,
-                      connected: fnConnected,
-                      ended: fnEnded).wait()
-        } catch {
-            return ""
-        }
-
-        return sessionId
-    }
-
-    public func makePush(_ sessionId: String, token: String, onError: @escaping (String?) -> Void) -> Bool {
-        guard let session = sessions[sessionId] else {
-            return false
-        }
-        do {
-            try session.sendPush(token) { [weak self] _, response, reason, _ in
-                if response == 0 {
-                    // make a publisher
-                    if let session = self?.sessions[sessionId] {
-                        // We know this has 2 parts because it will have been verified by sendPush
-                        let parts = token.split(separator: "/")
-                        session.makePublisher(UUID().uuidString, String(parts[0]), workspaceToken: String(parts[1]))
+            do {
+                try session.sendPull(token) { [weak self] _, response, reason, _ in
+                    if response == 0 {
+                        // make a subscriber
+                        if let session = self?.sessions[sessionId] {
+                            // We know this has 3 parts because it will have been verified by sendPull
+                            let parts = token.split(separator: "/")
+                            session.makeSubscriber(String(parts[2]), String(parts[0]), workspaceToken: String(parts[1]))
+                        }
+                        complete(.success(true))
+                    } else {
+                        complete(.failure(reason.map { .remote($0) } ?? .unknown))
                     }
-                } else {
-                    onError(reason)
                 }
+            } catch {
+                complete(.failure(.caught(error)))
             }
-        } catch {
-            return false
         }
-        return true
-    }
-
-    public func makePull(_ sessionId: String, token: String, onError: @escaping (String?) -> Void) -> Bool {
-        guard let session = sessions[sessionId] else {
-            return false
-        }
-        do {
-            try session.sendPull(token) { [weak self] _, response, reason, _ in
-                if response == 0 {
-                    // make a subscriber
-                    if let session = self?.sessions[sessionId] {
-                        // We know this has 3 parts because it will have been verified by sendPull
-                        let parts = token.split(separator: "/")
-                        session.makeSubscriber(String(parts[2]), String(parts[0]), workspaceToken: String(parts[1]))
-                    }
-                } else {
-                    onError(reason)
-                }
-            }
-        } catch {
-            return false
-        }
-        return true
     }
 
     public func close(_ sessionId: String, publisher: String) {
@@ -194,7 +200,6 @@ public class Flavor {
     }
     private var channel: Channel?
     private let fnStreamEstablished: LiveOnConnection
-    private let fnConnection: (String) -> Void
     private let fnEnded: LiveOnEnded
     private let fnFormatQuery: (String, String?) -> [MediaFormat]?
     private let clock: Clock
@@ -216,6 +221,7 @@ private class FlavorSession {
     fileprivate init(_ clock: Clock,
                      conn: Connection,
                      dialedOut: Bool,
+                     url: String? = nil,
                      sessionId: String? = nil,
                      formatQuery: @escaping (String, String?) -> [MediaFormat]?,
                      onEnded: @escaping LiveOnEnded,
@@ -235,6 +241,7 @@ private class FlavorSession {
         self.rpcCallId = 0
         self.trackId = 0
         self.dialedOut = dialedOut
+        self.url = url
         self.queue = DispatchQueue(label: sessionId)
         let bus = HeterogeneousBus()
         self.bus = bus
@@ -700,6 +707,7 @@ private class FlavorSession {
 
         return .nothing(event.info())
     }
+    let url: String?
     let queue: DispatchQueue
     let fnFormatQuery: (String, String?) -> [MediaFormat]?
     let dialedOut: Bool

--- a/Sources/SwiftVideo/net.tcp.swift
+++ b/Sources/SwiftVideo/net.tcp.swift
@@ -107,8 +107,11 @@ public final class Connection: Source<NetworkEvent>, ChannelInboundHandler {
 
     public func close() {
         if let ctx = self.ctx {
-            ctx.pipeline.eventLoop.execute { ctx.close(promise: nil) }
-        }
+            ctx.pipeline.eventLoop.execute {
+                ctx.close(promise: nil)
+            }
+            self.ended(self)
+        } else { print("ctx is gone") }
     }
     // Invoked when data are received from the client
     public func channelRead(context: ChannelHandlerContext, data: NIOAny) {

--- a/Sources/SwiftVideo/rpc/public.rpc.swift
+++ b/Sources/SwiftVideo/rpc/public.rpc.swift
@@ -18,6 +18,8 @@ public enum RpcError: Error {
     case timedOut
     case gone
     case invalidConfiguration
+    case caught(Error)
+    case remote(String)
     case unknown
 }
 

--- a/Sources/SwiftVideo/rtmp/rtmp.swift
+++ b/Sources/SwiftVideo/rtmp/rtmp.swift
@@ -184,7 +184,7 @@ public class Rtmp {
                 }
                 return strongSelf.handleCompletion($0, conn: conn)
             }
-            strongSelf.queue.async {
+            strongSelf.queue.sync {
                 strongSelf.handshaking[conn.ident] = conn >>> mix() >>> handshake >>> filter() >>> conn
             }
         }

--- a/Sources/SwiftVideo/rtmp/rtmp.swift
+++ b/Sources/SwiftVideo/rtmp/rtmp.swift
@@ -22,6 +22,21 @@ import BrightFutures
 
 public enum NoError: Error {}
 
+private func getApp(_ components: [String]) -> String? {
+    guard components.count > 0 else { return nil }
+    let start = components.index(0, offsetBy: 1)
+    let end = components.index(1, offsetBy: max(components.count - 2, 0))
+    let appComponents = components[start..<end]
+    return appComponents.joined(separator: "/")
+}
+
+private func getPlayPath(_ components: [String], _ query: [String]?) -> String? {
+    guard components.count > 0 else { return nil }
+    let base = components[components.count - 1] ?? (query?[safe: 1].map { String($0) } ?? "")
+    let queryString = query?[safe:0].map { "?" + $0 } ?? ""
+    return base + queryString
+}
+
 public class Rtmp {
     public init(_ clock: Clock,
                 bufferSize: TimePoint = TimePoint(500, 1000),
@@ -51,14 +66,9 @@ public class Rtmp {
             return false
         }
         let components = url.pathComponents
-        let app = components[safe: 1] ?? ""
+        let app = getApp(components) ?? ""
         let query = url.query?.split(separator: "/")
-        let playPath = { () -> String in
-            let base = components[safe: 2] ?? (query?[safe: 1].map { String($0) } ?? "")
-            let queryString = query <??> { if $0.count > 0 { return "?" + $0[0] } else { return "" } } <|> ""
-            return base + queryString
-        }()
-
+        let playPath = getPlayPath(components, query?.map { String($0) }) ?? ""
         let port = url.port ?? 1935
 
         let fnConnected = { [weak self] (conn: Connection) -> Void in

--- a/Sources/SwiftVideo/sample.pict.linux.swift
+++ b/Sources/SwiftVideo/sample.pict.linux.swift
@@ -274,7 +274,6 @@ func createPictureSample(_ size: Vector2,
 
 private func planesForFormat(_ format: PixelFormat, size: Vector2) throws -> [Plane] {
     let width = Int(size.x)
-    let height = Int(size.y)
     switch format {
     case .nv12:
         return [Plane(size: size, stride: width, bitDepth: 8, components: [.y]),


### PR DESCRIPTION
- Reorder composer bind command so that binding an asset to the element happens after the callback.  This is important incase an asset needs to do some asynchronous preparation before being attached to the composer.
- Handshake bugfix and fix some linter errors in the rtmp stack
- Allow multilevel app paths in rtmp stack (fixes UStream compatibility)
- Flavor server can now reuse connections for multiple sessions
