### PR TITLE
WIP Apple VideoToolbox VP9 support - To be merged after Xcode 12 is released

### DIFF
--- a/Examples/RtmpServer/Sources/RtmpServer/main.swift
+++ b/Examples/RtmpServer/Sources/RtmpServer/main.swift
@@ -33,7 +33,7 @@ let onConnection: LiveOnConnection = { pub, sub in
         // to it. Releasing the reference will close the connection an end the stream.
         // You can create more sophisticated graphs with decoders, buses, and other components.
         subs[sub.assetId()] = src >>> Tx { sample in
-            print("got sample \(sample.pts().toString()) type = \(sample.mediaType())")
+            print("got sample \(sample.pts().toString()) type = \(sample.mediaType()) size = \(sample.data().count)")
             return .nothing(nil)
         }
     }

--- a/Sources/CSwiftVideo/include/CSwiftVideo.h
+++ b/Sources/CSwiftVideo/include/CSwiftVideo.h
@@ -27,10 +27,34 @@
 extern "C" {
 #endif
 
+typedef enum {
+   VP9ColorSpace_Unknown = 0,
+   VP9ColorSpace_BT_601 = 1,
+   VP9ColorSpace_BT_709 = 2,
+   VP9ColorSpace_SMPTE_170 = 3,
+   VP9ColorSpace_SMPTE_240 = 4,
+   VP9ColorSpace_BT_2020 = 5,
+   VP9ColorSpace_Reserved = 6,
+   VP9ColorSpace_SRGB = 7
+} VP9ColorSpace;
+
+typedef struct {
+   int width;
+   int height;
+   int displayWidth;
+   int displayHeight;
+   int bitDepth;
+   VP9ColorSpace colorSpace;
+   int subSamplingX;
+   int subSamplingY;
+   int fullSwingColor;
+   int profile;
+} VP9FrameProperties;
+
 int aac_parse_asc(const void* data, int64_t size, int* channels, int* sample_rate, int* samples_per_frame);
 int h264_sps_frame_size(const void* data, int64_t size, int* width, int* height);
 int vp9_is_keyframe(const void* data, int64_t size, int* is_keyframe);
-int vp9_frame_size(const void* data, int64_t size, int* width, int* height);
+int vp9_frame_properties(const void* data, int64_t size, VP9FrameProperties* props);
 
 #if defined(linux)
 void generateRandomBytes(void* buf, size_t size);

--- a/Sources/CSwiftVideo/include/CSwiftVideo.h
+++ b/Sources/CSwiftVideo/include/CSwiftVideo.h
@@ -29,6 +29,8 @@ extern "C" {
 
 int aac_parse_asc(const void* data, int64_t size, int* channels, int* sample_rate, int* samples_per_frame);
 int h264_sps_frame_size(const void* data, int64_t size, int* width, int* height);
+int vp9_is_keyframe(const void* data, int64_t size, int* is_keyframe);
+int vp9_frame_size(const void* data, int64_t size, int* width, int* height);
 
 #if defined(linux)
 void generateRandomBytes(void* buf, size_t size);

--- a/Sources/CSwiftVideo/shim.cpp
+++ b/Sources/CSwiftVideo/shim.cpp
@@ -368,6 +368,3 @@ extern "C" {
         return val;
     }
 }
-
-
-

--- a/Sources/CSwiftVideo/shim.cpp
+++ b/Sources/CSwiftVideo/shim.cpp
@@ -293,7 +293,7 @@ extern "C" {
         } else {
             props->subSamplingX = props->subSamplingY = 0;
             decoder.get_bits(1); // reserved 0
-            if(profile != 1 && profile != 3) {
+            if(props->profile != 1 && props->profile != 3) {
                 return 0;
             }
         }
@@ -351,7 +351,7 @@ extern "C" {
         decoder.get_bits(1); // show_frame
         decoder.get_bits(1); // error_resilient_mode
         auto sync_code = *decoder.get_bits(24);
-        if(sync_code = 0x498342 && vp9_bitdepth_colorspace_sampling(decoder, props)) {
+        if(sync_code == 0x498342 && vp9_bitdepth_colorspace_sampling(decoder, props)) {
             if(decoder.alignment() > 0) {
                 decoder.get_bits(8 - decoder.alignment());
             }

--- a/Sources/CSwiftVideo/shim.cpp
+++ b/Sources/CSwiftVideo/shim.cpp
@@ -113,6 +113,11 @@ public:
         ptr = (uint8_t*)(base + (pos / 8));
         return accumulator;
     }
+
+    int64_t alignment() const {
+        return pos % 8;
+    }
+
 private:
     int64_t zeroes() {
         uint8_t* p = ptr;
@@ -288,7 +293,9 @@ extern "C" {
         } else {
             props->subSamplingX = props->subSamplingY = 0;
             decoder.get_bits(1); // reserved 0
-            return 0;
+            if(profile != 1 && profile != 3) {
+                return 0;
+            }
         }
         return 1;
     }
@@ -345,7 +352,9 @@ extern "C" {
         decoder.get_bits(1); // error_resilient_mode
         auto sync_code = *decoder.get_bits(24);
         if(sync_code = 0x498342 && vp9_bitdepth_colorspace_sampling(decoder, props)) {
-            auto refresh_frames_flag = *decoder.get_bits(8);
+            if(decoder.alignment() > 0) {
+                decoder.get_bits(8 - decoder.alignment());
+            }
             vp9_frame_size(decoder, props);
             return 1;
         }

--- a/Sources/SwiftVideo/dec.video.apple.swift
+++ b/Sources/SwiftVideo/dec.video.apple.swift
@@ -193,8 +193,8 @@ private func videoFormatFromVP9Header(_ sample: CodedMediaSample) throws -> CMVi
     var formatDesc: CMVideoFormatDescription?
     _ = CMVideoFormatDescriptionCreate(kCFAllocatorDefault,
       kCMVideoCodecType_VP9,
-      videoDesc.width,
-      videoDesc.height,
+      Int32(videoDesc.size.x),
+      Int32(videoDesc.size.y),
       nil,
       &formatDesc)
     return formatDesc

--- a/Sources/SwiftVideo/dec.video.apple.swift
+++ b/Sources/SwiftVideo/dec.video.apple.swift
@@ -192,11 +192,11 @@ private func videoFormatFromVP9Header(_ sample: CodedMediaSample) throws -> CMVi
     }
     var formatDesc: CMVideoFormatDescription?
     _ = CMVideoFormatDescriptionCreate(allocator: kCFAllocatorDefault,
-      codecType: kCMVideoCodecType_VP9,
-      width: Int32(videoDesc.size.x),
-      height: Int32(videoDesc.size.y),
-      extensions: nil,
-      formatDescription: &formatDesc)
+          codecType: kCMVideoCodecType_VP9,
+          width: Int32(videoDesc.size.x),
+          height: Int32(videoDesc.size.y),
+          extensions: nil,
+          formatDescriptionOut: &formatDesc)
     return formatDesc
 }
 private func videoFormatFromAVCParameterSets( _ paramSets: [[UInt8]]) throws -> CMVideoFormatDescription? {

--- a/Sources/SwiftVideo/dec.video.apple.swift
+++ b/Sources/SwiftVideo/dec.video.apple.swift
@@ -38,7 +38,7 @@ public class AppleVideoDecoder: Tx<CodedMediaSample, PictureSample> {
             guard let strongSelf = self else {
                 return .gone
             }
-            guard [.avc, .hevc].contains(sample.mediaFormat()) else {
+            guard [.avc, .hevc, .vp9].contains(sample.mediaFormat()) else {
                 return .error(EventError("dec.video.apple",
                    -1,
                    "\(sample.mediaFormat()) not supported. AppleVideoDecoder only supports AVC and HEVC"))
@@ -185,6 +185,10 @@ public class AppleVideoDecoder: Tx<CodedMediaSample, PictureSample> {
     private let decodeQueue: DispatchQueue
 }
 
+private func videoFormatFromVP9Header(_ data: Data) -> CMVideoFormatDescription? {
+    
+    return nil
+}
 private func videoFormatFromAVCParameterSets( _ paramSets: [[UInt8]]) throws -> CMVideoFormatDescription? {
     let pmSetPtrs: [UnsafePointer<UInt8>] = try paramSets.map {
         try $0.withUnsafeBufferPointer {

--- a/Sources/SwiftVideo/dec.video.apple.swift
+++ b/Sources/SwiftVideo/dec.video.apple.swift
@@ -191,12 +191,12 @@ private func videoFormatFromVP9Header(_ sample: CodedMediaSample) throws -> CMVi
         return nil
     }
     var formatDesc: CMVideoFormatDescription?
-    _ = CMVideoFormatDescriptionCreate(kCFAllocatorDefault,
-      kCMVideoCodecType_VP9,
-      Int32(videoDesc.size.x),
-      Int32(videoDesc.size.y),
-      nil,
-      &formatDesc)
+    _ = CMVideoFormatDescriptionCreate(allocator: kCFAllocatorDefault,
+      codecType: kCMVideoCodecType_VP9,
+      width: Int32(videoDesc.size.x),
+      height: Int32(videoDesc.size.y),
+      extensions: nil,
+      formatDescription: &formatDesc)
     return formatDesc
 }
 private func videoFormatFromAVCParameterSets( _ paramSets: [[UInt8]]) throws -> CMVideoFormatDescription? {

--- a/Sources/SwiftVideo/dec.video.apple.swift
+++ b/Sources/SwiftVideo/dec.video.apple.swift
@@ -155,7 +155,7 @@ public class AppleVideoDecoder: Tx<CodedMediaSample, PictureSample> {
         if let format = formatDesc {
             var session: VTDecompressionSession?
             let decoderSpecification = [:] as CFDictionary
-            if #available(macOS 10.11, *) {
+            if #available(macOS 11.0, *) {
                 VTRegisterSupplementalVideoDecoderIfAvailable(kCMVideoCodecType_VP9)
             }
             let result = VTDecompressionSessionCreate(allocator: kCFAllocatorDefault,

--- a/Sources/SwiftVideo/dec.video.apple.swift
+++ b/Sources/SwiftVideo/dec.video.apple.swift
@@ -155,9 +155,9 @@ public class AppleVideoDecoder: Tx<CodedMediaSample, PictureSample> {
         if let format = formatDesc {
             var session: VTDecompressionSession?
             let decoderSpecification = [:] as CFDictionary
-            #if os(macOS)
-            VTRegisterSupplementalVideoDecoderIfAvailable(kCMVideoCodecType_VP9)
-            #endif
+            if #available(macOS 10.11, *) {
+                VTRegisterSupplementalVideoDecoderIfAvailable(kCMVideoCodecType_VP9)
+            }
             let result = VTDecompressionSessionCreate(allocator: kCFAllocatorDefault,
                                           formatDescription: format,
                                           decoderSpecification: decoderSpecification,

--- a/Sources/SwiftVideo/dec.video.apple.swift
+++ b/Sources/SwiftVideo/dec.video.apple.swift
@@ -185,9 +185,19 @@ public class AppleVideoDecoder: Tx<CodedMediaSample, PictureSample> {
     private let decodeQueue: DispatchQueue
 }
 
-private func videoFormatFromVP9Header(_ data: Data) -> CMVideoFormatDescription? {
-    
-    return nil
+private func videoFormatFromVP9Header(_ sample: CodedMediaSample) throws -> CMVideoFormatDescription? {
+    let desc = try basicMediaDescription(sample)
+    guard case .video(let videoDesc) = desc else {
+        return nil
+    }
+    var formatDesc: CMVideoFormatDescription?
+    _ = CMVideoFormatDescriptionCreate(kCFAllocatorDefault,
+      kCMVideoCodecType_VP9,
+      videoDesc.width,
+      videoDesc.height,
+      nil,
+      &formatDesc)
+    return formatDesc
 }
 private func videoFormatFromAVCParameterSets( _ paramSets: [[UInt8]]) throws -> CMVideoFormatDescription? {
     let pmSetPtrs: [UnsafePointer<UInt8>] = try paramSets.map {

--- a/Sources/SwiftVideo/dec.video.apple.swift
+++ b/Sources/SwiftVideo/dec.video.apple.swift
@@ -155,6 +155,9 @@ public class AppleVideoDecoder: Tx<CodedMediaSample, PictureSample> {
         if let format = formatDesc {
             var session: VTDecompressionSession?
             let decoderSpecification = [:] as CFDictionary
+            #if os(macOS)
+            VTRegisterSupplementalVideoDecoderIfAvailable(kCMVideoCodecType_VP9)
+            #endif
             let result = VTDecompressionSessionCreate(allocator: kCFAllocatorDefault,
                                           formatDescription: format,
                                           decoderSpecification: decoderSpecification,

--- a/Sources/SwiftVideo/dec.video.apple.swift
+++ b/Sources/SwiftVideo/dec.video.apple.swift
@@ -22,6 +22,7 @@ import Dispatch
 enum DecodeError: Error {
     case invalidBase
     case osstatus(Int32)
+    case unsupportedCodec
 }
 
 public class AppleVideoDecoder: Tx<CodedMediaSample, PictureSample> {
@@ -79,68 +80,58 @@ public class AppleVideoDecoder: Tx<CodedMediaSample, PictureSample> {
                                                blockBufferOut: &buffer)
             return buffer
         }
-        guard let dataBuffer = dataBufferWk, let dcr = sample.sideData()["config"] else {
+        guard let dataBuffer = dataBufferWk else {
             print("Failed to create buffer")
             return .error(EventError("dec.video.apple", -2, "Failed to create buffer"))
         }
-
-        do {
-            // TODO: HEVC Support
-            let paramSets = parameterSetsFromAVCC(dcr)
-            let formatDesc = try videoFormatFromAVCParameterSets(paramSets)
-            let pts = rescale(sample.pts(), 90000).value
-            let dts = rescale(sample.dts(), 90000).value
-            var videoSampleTimingInfo = CMSampleTimingInfo(duration: CMTimeMake(value: 1, timescale: 1),
-                                           presentationTimeStamp: CMTimeMake(value: pts, timescale: 90000),
-                                           decodeTimeStamp: CMTimeMake(value: dts, timescale: 90000))
-            var sampleBuffer: CMSampleBuffer?
-            var sampleSize = [sample.data().count]
-            CMSampleBufferCreate(allocator: kCFAllocatorDefault,
-                                 dataBuffer: dataBuffer,
-                                 dataReady: true,
-                                 makeDataReadyCallback: nil,
-                                 refcon: nil,
-                                 formatDescription: formatDesc,
-                                 sampleCount: 1,
-                                 sampleTimingEntryCount: 1,
-                                 sampleTimingArray: &videoSampleTimingInfo,
-                                 sampleSizeEntryCount: 1,
-                                 sampleSizeArray: &sampleSize,
-                                 sampleBufferOut: &sampleBuffer)
-            if let sampleBuffer = sampleBuffer {
-                let flags: VTDecodeFrameFlags = [._1xRealTimePlayback,
-                                                 ._EnableTemporalProcessing,
-                                                 ._EnableAsynchronousDecompression]
-                let result = VTDecompressionSessionDecodeFrame(session,
-                                                  sampleBuffer: sampleBuffer,
-                                                  flags: flags,
-                                                  infoFlagsOut: nil) { [weak self] (_, _, imgBuffer, pts, _) in
-                                                    guard let strongSelf = self, let imgBuffer = imgBuffer else {
-                                                        return
-                                                    }
-                                                    let ptsTime = TimePoint(pts.value, Int64(pts.timescale))
-                                                    let img = ImageBuffer(imgBuffer)
-                                                    let pic = PictureSample(img,
-                                                                            assetId: sample.assetId(),
-                                                                            workspaceId: sample.workspaceId(),
-                                                                            time: strongSelf.clock.current(),
-                                                                            pts: ptsTime)
-                                                    strongSelf.sampleQueue.sync {
-                                                        strongSelf.output.append(pic)
-                                                        strongSelf.output = strongSelf
-                                                            .output.sorted { $0.pts() < $1.pts() }
-                                                    }
-                    }
-                if result != 0 {
-                    print("result=\(result)")
-                    return .error(EventError("dec.video.apple", Int(result), "OSStatus, decode failed"))
+        let pts = rescale(sample.pts(), 90000).value
+        let dts = rescale(sample.dts(), 90000).value
+        var videoSampleTimingInfo = CMSampleTimingInfo(duration: CMTimeMake(value: 1, timescale: 1),
+                                       presentationTimeStamp: CMTimeMake(value: pts, timescale: 90000),
+                                       decodeTimeStamp: CMTimeMake(value: dts, timescale: 90000))
+        var sampleBuffer: CMSampleBuffer?
+        var sampleSize = [sample.data().count]
+        CMSampleBufferCreate(allocator: kCFAllocatorDefault,
+                             dataBuffer: dataBuffer,
+                             dataReady: true,
+                             makeDataReadyCallback: nil,
+                             refcon: nil,
+                             formatDescription: formatDesc,
+                             sampleCount: 1,
+                             sampleTimingEntryCount: 1,
+                             sampleTimingArray: &videoSampleTimingInfo,
+                             sampleSizeEntryCount: 1,
+                             sampleSizeArray: &sampleSize,
+                             sampleBufferOut: &sampleBuffer)
+        if let sampleBuffer = sampleBuffer {
+            let flags: VTDecodeFrameFlags = [._1xRealTimePlayback,
+                                             ._EnableTemporalProcessing,
+                                             ._EnableAsynchronousDecompression]
+            let result = VTDecompressionSessionDecodeFrame(session,
+                                              sampleBuffer: sampleBuffer,
+                                              flags: flags,
+                                              infoFlagsOut: nil) { [weak self] (_, _, imgBuffer, pts, _) in
+                                                guard let strongSelf = self, let imgBuffer = imgBuffer else {
+                                                    return
+                                                }
+                                                let ptsTime = TimePoint(pts.value, Int64(pts.timescale))
+                                                let img = ImageBuffer(imgBuffer)
+                                                let pic = PictureSample(img,
+                                                                        assetId: sample.assetId(),
+                                                                        workspaceId: sample.workspaceId(),
+                                                                        time: strongSelf.clock.current(),
+                                                                        pts: ptsTime)
+                                                strongSelf.sampleQueue.sync {
+                                                    strongSelf.output.append(pic)
+                                                    strongSelf.output = strongSelf
+                                                        .output.sorted { $0.pts() < $1.pts() }
+                                                }
                 }
+            if result != 0 {
+                print("result=\(result)")
+                return .error(EventError("dec.video.apple", Int(result), "OSStatus, decode failed"))
             }
-        } catch {
-            // error
-            return .error(EventError("dec.video.apple", -4, "Caught decode error \(error)"))
         }
-        
         return self.sampleQueue.sync {
             if let outSample = self.output[safe:0], self.output.count >= 5 {
                 self.output.removeFirst()
@@ -152,15 +143,14 @@ public class AppleVideoDecoder: Tx<CodedMediaSample, PictureSample> {
     }
     private func setupSession(_ sample: CodedMediaSample) throws {
         let desc = try basicMediaDescription(sample)
-        guard case .video(let videoDesc) = desc, let dcr = sample.sideData()["config"] else {
+        guard case .video(let videoDesc) = desc else {
             return
         }
         let pixelBufferOptions =
             [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange,
              kCVPixelBufferWidthKey as String: Int(videoDesc.size.x),
              kCVPixelBufferHeightKey as String: Int(videoDesc.size.y)] as CFDictionary
-        let paramSets = parameterSetsFromAVCC(dcr)
-        let formatDesc = try videoFormatFromAVCParameterSets(paramSets)
+        formatDesc = try videoFormatDescription(sample)
 
         if let format = formatDesc {
             var session: VTDecompressionSession?
@@ -180,25 +170,45 @@ public class AppleVideoDecoder: Tx<CodedMediaSample, PictureSample> {
     }
     private var output: [PictureSample]
     private var session: VTDecompressionSession?
+    private var formatDesc: CMVideoFormatDescription?
     private let clock: Clock
     private let sampleQueue: DispatchQueue
     private let decodeQueue: DispatchQueue
 }
 
-private func videoFormatFromVP9Header(_ sample: CodedMediaSample) throws -> CMVideoFormatDescription? {
+private func videoFormatDescription(_ sample: CodedMediaSample) throws -> CMVideoFormatDescription? {
+    switch(sample.mediaFormat()) {
+    case .avc:
+        guard let dcr = sample.sideData()["config"] else {
+            throw MediaDescriptionError.invalidMetadata
+        }
+        let paramSets = parameterSetsFromAVCC(dcr)
+        return try videoFormatFromAVCParameterSets(paramSets)
+    case .vp9:
+        return try videoFormatFromVP9(sample)
+    default:
+        throw DecodeError.unsupportedCodec
+    }
+}
+
+private func videoFormatFromVP9(_ sample: CodedMediaSample) throws -> CMVideoFormatDescription? {
     let desc = try basicMediaDescription(sample)
     guard case .video(let videoDesc) = desc else {
         return nil
     }
     var formatDesc: CMVideoFormatDescription?
+    let extensions = [
+        kCMFormatDescriptionExtension_FullRangeVideo as String: videoDesc.fullRangeColor
+    ] as CFDictionary
     _ = CMVideoFormatDescriptionCreate(allocator: kCFAllocatorDefault,
           codecType: kCMVideoCodecType_VP9,
           width: Int32(videoDesc.size.x),
           height: Int32(videoDesc.size.y),
-          extensions: nil,
+          extensions: extensions,
           formatDescriptionOut: &formatDesc)
     return formatDesc
 }
+
 private func videoFormatFromAVCParameterSets( _ paramSets: [[UInt8]]) throws -> CMVideoFormatDescription? {
     let pmSetPtrs: [UnsafePointer<UInt8>] = try paramSets.map {
         try $0.withUnsafeBufferPointer {

--- a/Sources/SwiftVideo/dec.video.apple.swift
+++ b/Sources/SwiftVideo/dec.video.apple.swift
@@ -155,9 +155,11 @@ public class AppleVideoDecoder: Tx<CodedMediaSample, PictureSample> {
         if let format = formatDesc {
             var session: VTDecompressionSession?
             let decoderSpecification = [:] as CFDictionary
+            #if os(macOS)
             if #available(macOS 11.0, *) {
                 VTRegisterSupplementalVideoDecoderIfAvailable(kCMVideoCodecType_VP9)
             }
+            #endif
             let result = VTDecompressionSessionCreate(allocator: kCFAllocatorDefault,
                                           formatDescription: format,
                                           decoderSpecification: decoderSpecification,

--- a/Sources/SwiftVideo/enc.video.apple.swift
+++ b/Sources/SwiftVideo/enc.video.apple.swift
@@ -40,7 +40,7 @@ public class AppleVideoEncoder: Tx<PictureSample, [CodedMediaSample]> {
                     return kCMVideoCodecType_H264
             }
         }()
-        VTCompressionSessionCreate(allocator: kCFAllocatorDefault,
+        let result = VTCompressionSessionCreate(allocator: kCFAllocatorDefault,
            width: Int32(frame.width),
            height: Int32(frame.height),
            codecType: codecType,

--- a/Sources/SwiftVideo/enc.video.apple.swift
+++ b/Sources/SwiftVideo/enc.video.apple.swift
@@ -40,8 +40,8 @@ public class AppleVideoEncoder: Tx<PictureSample, [CodedMediaSample]> {
                 return kCMVideoCodecType_H264
             }
         }()
-        if #available(macOS 10.11, *) {
-            VTRegisterSupplementalVideoDecoderIfAvailable(kCMVideoCodecType_VP9)
+        if #available(macOS 11.0, *) {
+            VTRegisterSupplementalVideoEncoderIfAvailable(kCMVideoCodecType_VP9)
         }
         let result = VTCompressionSessionCreate(allocator: kCFAllocatorDefault,
            width: Int32(frame.width),

--- a/Sources/SwiftVideo/enc.video.apple.swift
+++ b/Sources/SwiftVideo/enc.video.apple.swift
@@ -26,13 +26,24 @@ public class AppleVideoEncoder: Tx<PictureSample, [CodedMediaSample]> {
     }
 
     public init(format: MediaFormat, frame: CGSize, bitrate: Int = 500000) {
-        assert(format == .avc || format == .hevc, "AppleVideoEncoder only supports AVC and HEVC")
+        //assert(format == .avc || format == .hevc, "AppleVideoEncoder only supports AVC and HEVC")
         self.queue = DispatchQueue.init(label: "cezium.encode.video")
-
+        let codecType = {
+            switch format {
+                case .avc:
+                    return kCMVideoCodecType_H264
+                case .hevc:
+                    return kCMVideoCodecType_HEVC
+                case .vp9:
+                    return kCMVideoCodecType_VP9
+                default:
+                    return kCMVideoCodecType_H264
+            }
+        }()
         VTCompressionSessionCreate(allocator: kCFAllocatorDefault,
            width: Int32(frame.width),
            height: Int32(frame.height),
-           codecType: format == .avc ? kCMVideoCodecType_H264 : kCMVideoCodecType_HEVC,
+           codecType: codecType
            encoderSpecification: [kVTCompressionPropertyKey_ExpectedFrameRate: 30] as CFDictionary,
            imageBufferAttributes: pixelBufferOptions(frame),
            compressedDataAllocator: nil,

--- a/Sources/SwiftVideo/enc.video.apple.swift
+++ b/Sources/SwiftVideo/enc.video.apple.swift
@@ -30,16 +30,19 @@ public class AppleVideoEncoder: Tx<PictureSample, [CodedMediaSample]> {
         self.queue = DispatchQueue.init(label: "cezium.encode.video")
         let codecType = { () -> CMVideoCodecType in
             switch format {
-                case .avc:
-                    return kCMVideoCodecType_H264
-                case .hevc:
-                    return kCMVideoCodecType_HEVC
-                case .vp9:
-                    return kCMVideoCodecType_VP9
-                default:
-                    return kCMVideoCodecType_H264
+            case .avc:
+                return kCMVideoCodecType_H264
+            case .hevc:
+                return kCMVideoCodecType_HEVC
+            case .vp9:
+                return kCMVideoCodecType_VP9
+            default:
+                return kCMVideoCodecType_H264
             }
         }()
+        #if os(macOS)
+        VTRegisterSupplementalVideoDecoderIfAvailable(kCMVideoCodecType_VP9)
+        #endif
         let result = VTCompressionSessionCreate(allocator: kCFAllocatorDefault,
            width: Int32(frame.width),
            height: Int32(frame.height),

--- a/Sources/SwiftVideo/enc.video.apple.swift
+++ b/Sources/SwiftVideo/enc.video.apple.swift
@@ -40,9 +40,9 @@ public class AppleVideoEncoder: Tx<PictureSample, [CodedMediaSample]> {
                 return kCMVideoCodecType_H264
             }
         }()
-        #if os(macOS)
-        VTRegisterSupplementalVideoDecoderIfAvailable(kCMVideoCodecType_VP9)
-        #endif
+        if #available(macOS 10.11, *) {
+            VTRegisterSupplementalVideoDecoderIfAvailable(kCMVideoCodecType_VP9)
+        }
         let result = VTCompressionSessionCreate(allocator: kCFAllocatorDefault,
            width: Int32(frame.width),
            height: Int32(frame.height),

--- a/Sources/SwiftVideo/enc.video.apple.swift
+++ b/Sources/SwiftVideo/enc.video.apple.swift
@@ -28,7 +28,7 @@ public class AppleVideoEncoder: Tx<PictureSample, [CodedMediaSample]> {
     public init(format: MediaFormat, frame: CGSize, bitrate: Int = 500000) {
         //assert(format == .avc || format == .hevc, "AppleVideoEncoder only supports AVC and HEVC")
         self.queue = DispatchQueue.init(label: "cezium.encode.video")
-        let codecType = {
+        let codecType = { () -> CMVideoCodecType in
             switch format {
                 case .avc:
                     return kCMVideoCodecType_H264
@@ -43,7 +43,7 @@ public class AppleVideoEncoder: Tx<PictureSample, [CodedMediaSample]> {
         VTCompressionSessionCreate(allocator: kCFAllocatorDefault,
            width: Int32(frame.width),
            height: Int32(frame.height),
-           codecType: codecType
+           codecType: codecType,
            encoderSpecification: [kVTCompressionPropertyKey_ExpectedFrameRate: 30] as CFDictionary,
            imageBufferAttributes: pixelBufferOptions(frame),
            compressedDataAllocator: nil,

--- a/Sources/SwiftVideo/enc.video.apple.swift
+++ b/Sources/SwiftVideo/enc.video.apple.swift
@@ -40,9 +40,6 @@ public class AppleVideoEncoder: Tx<PictureSample, [CodedMediaSample]> {
                 return kCMVideoCodecType_H264
             }
         }()
-        if #available(macOS 11.0, *) {
-            VTRegisterSupplementalVideoEncoderIfAvailable(kCMVideoCodecType_VP9)
-        }
         let result = VTCompressionSessionCreate(allocator: kCFAllocatorDefault,
            width: Int32(frame.width),
            height: Int32(frame.height),

--- a/Sources/SwiftVideo/sample.pict.swift
+++ b/Sources/SwiftVideo/sample.pict.swift
@@ -32,6 +32,15 @@ public enum PixelFormat {
     case invalid
 }
 
+public enum ColorSpace {
+    case bt601
+    case bt709
+    case bt2020
+    case smpte170
+    case smpte240
+    case sRGB
+}
+
 // swiftlint:disable identifier_name
 public enum Component {
     case r


### PR DESCRIPTION
Apple seems to have added VP9 support to VideoToolbox. The FFmpeg encoder/decoder classes already support VP9.